### PR TITLE
feat(cache): hash long keys to avoid DynamoDB 2048-byte limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ npm install @blastorg/fastify-aws-dynamodb-cache
 
 This packages helps you cache your API response in DynamoDB, which allows your lambda executions to all have access to the same cached responses.
 
+> ⚠️ **NOTICE — BREAKING CHANGE:** When a request URL exceeds `hashThresholdBytes` (default `2048`)
+> the cache key is hashed instead of using the raw URL. This changes the DynamoDB partition key for
+> any route with URLs over that size, so their previously-cached entries are orphaned and repopulate
+> on the next request. No action is required. Adjust `hashThresholdBytes` to change the size at which
+> this kicks in.
+
 ```ts
 import Fastify from "fastify";
 import { dynamodbCache } from "@blastorg/fastify-aws-dynamodb-cache";
@@ -42,6 +48,7 @@ const fastify = Fastify().register(dynamodbCache, {
   defaultTTLSeconds: 30, // Default TTL (seconds), which would be used if no TTL is specified on the endpoint.
   disableCache: true, // Optional! If you want to disable caching from being set on endpoints, you can set this to true. Set it to false or leave it empty to enable cache.
   passthroughQueryParam: "_t", // Optional! If you want to define a query parameter for all endpoints, which will be used to bypass the cache (will set 'x-cache: ignored').
+  hashThresholdBytes: 2048, // Optional! Byte size above which a cache key is hashed automatically. Defaults to 2048 (DynamoDB's hash key limit).
 });
 
 fastify.get(
@@ -51,6 +58,7 @@ fastify.get(
       cache: {
         cacheEnabled: true, // Set to true if endpoint responses should be cached. If you don't want to cache responses set it to false, or don't specify it.
         ttlSeconds: 10, // Optional! TTL on the cached value
+        hashKey: true, // Optional! Force hashing of this route's cache key regardless of its size. Keys are also hashed automatically when they exceed hashThresholdBytes.
       },
     },
     schema: {},

--- a/src/helpers/buildCacheKey.test.ts
+++ b/src/helpers/buildCacheKey.test.ts
@@ -1,0 +1,53 @@
+import {
+  buildCacheKey,
+  HASHED_KEY_PREFIX,
+  DEFAULT_HASH_THRESHOLD_BYTES,
+} from "./buildCacheKey";
+
+describe("buildCacheKey", () => {
+  it("should return the raw URL unchanged for a short URL with no flag", () => {
+    const url = "/users/123?filter=active";
+    expect(buildCacheKey(url)).toEqual({ key: url, hashed: false });
+  });
+
+  it("should hash the key when hashKey is true", () => {
+    const url = "/users/123";
+    const result = buildCacheKey(url, { hashKey: true });
+    expect(result.hashed).toBe(true);
+    expect(result.key.startsWith(HASHED_KEY_PREFIX)).toBe(true);
+    expect(result.key).not.toContain(url);
+  });
+
+  it("should auto-hash a URL longer than the threshold even without the flag", () => {
+    const url = "/search?q=" + "a".repeat(DEFAULT_HASH_THRESHOLD_BYTES);
+    const result = buildCacheKey(url);
+    expect(result.hashed).toBe(true);
+    expect(result.key.startsWith(HASHED_KEY_PREFIX)).toBe(true);
+  });
+
+  it("should not hash a URL at or under the threshold", () => {
+    const url = "/x".repeat(10);
+    expect(buildCacheKey(url, { hashThresholdBytes: url.length }).hashed).toBe(
+      false
+    );
+  });
+
+  it("should produce the same key for the same URL", () => {
+    const url = "/users/123?filter=active";
+    expect(buildCacheKey(url, { hashKey: true })).toEqual(
+      buildCacheKey(url, { hashKey: true })
+    );
+  });
+
+  it("should produce different keys for different URLs", () => {
+    const a = buildCacheKey("/users/1", { hashKey: true });
+    const b = buildCacheKey("/users/2", { hashKey: true });
+    expect(a.key).not.toBe(b.key);
+  });
+
+  it("should honor a custom hashThresholdBytes", () => {
+    const url = "/abcdef";
+    expect(buildCacheKey(url, { hashThresholdBytes: 3 }).hashed).toBe(true);
+    expect(buildCacheKey(url, { hashThresholdBytes: 100 }).hashed).toBe(false);
+  });
+});

--- a/src/helpers/buildCacheKey.ts
+++ b/src/helpers/buildCacheKey.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Prefix applied to hashed cache keys so they are distinguishable from raw
+ * URL keys (which always start with "/") when inspecting the table.
+ */
+export const HASHED_KEY_PREFIX = "sha256:";
+
+/**
+ * Default byte size at which a cache key is hashed automatically. Matches
+ * DynamoDB's maximum partition (hash) key size of 2048 bytes.
+ */
+export const DEFAULT_HASH_THRESHOLD_BYTES = 2048;
+
+interface BuildCacheKeyOptions {
+  /**
+   * Force hashing of the key regardless of its size.
+   */
+  hashKey?: boolean;
+  /**
+   * Byte size above which the key is hashed automatically. Defaults to
+   * {@link DEFAULT_HASH_THRESHOLD_BYTES}.
+   */
+  hashThresholdBytes?: number;
+}
+
+/**
+ * Builds the DynamoDB partition key for a request URL.
+ *
+ * The key is hashed when `hashKey` is true, or automatically when the URL
+ * exceeds `hashThresholdBytes` (a safety net against DynamoDB's 2048-byte hash
+ * key limit). Otherwise the raw URL is used.
+ *
+ * @param url - The request URL (path + query string).
+ * @param options - Hashing options.
+ * @returns The cache key and whether it was hashed.
+ */
+export const buildCacheKey = (
+  url: string,
+  {
+    hashKey,
+    hashThresholdBytes = DEFAULT_HASH_THRESHOLD_BYTES,
+  }: BuildCacheKeyOptions = {},
+): { key: string; hashed: boolean } => {
+  const shouldHash =
+    hashKey === true || Buffer.byteLength(url, "utf8") > hashThresholdBytes;
+
+  if (!shouldHash) {
+    return { key: url, hashed: false };
+  }
+
+  const digest = createHash("sha256").update(url).digest("hex");
+  return { key: `${HASHED_KEY_PREFIX}${digest}`, hashed: true };
+};

--- a/src/hooks/onRequest.ts
+++ b/src/hooks/onRequest.ts
@@ -2,26 +2,33 @@ import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { FastifyRequest, FastifyReply } from "fastify";
 import { onRequestAsyncHookHandler } from "fastify/types/hooks";
 import { hasQueryParam } from "../helpers/hasQueryParams";
+import { buildCacheKey } from "../helpers/buildCacheKey";
 
 interface CreateOnRequestHookOptions {
   dynamoClient: DynamoDBClient;
   tableName: string;
   passthroughQueryParam?: string;
+  hashKey?: boolean;
+  hashThresholdBytes?: number;
 }
 
 export const createOnRequestHook = ({
   dynamoClient,
   tableName,
   passthroughQueryParam,
+  hashKey,
+  hashThresholdBytes,
 }: CreateOnRequestHookOptions) => {
   const onRequestHook: onRequestAsyncHookHandler = async (
     request: FastifyRequest,
     reply: FastifyReply
   ) => {
+    const { key } = buildCacheKey(request.url, { hashKey, hashThresholdBytes });
+
     const command = new GetItemCommand({
       TableName: tableName,
       Key: {
-        path: { S: request.url },
+        path: { S: key },
       },
     });
 

--- a/src/hooks/onSend.ts
+++ b/src/hooks/onSend.ts
@@ -1,38 +1,52 @@
 import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { FastifyRequest, FastifyReply } from "fastify";
 import { onSendAsyncHookHandler } from "fastify/types/hooks";
+import { buildCacheKey } from "../helpers/buildCacheKey";
 
 interface CreateOnSendHookOptions {
   dynamoClient: DynamoDBClient;
   tableName: string;
   ttlSeconds: number;
+  hashKey?: boolean;
+  hashThresholdBytes?: number;
 }
 
 export const createOnSendHook = ({
   dynamoClient,
   tableName,
   ttlSeconds,
+  hashKey,
+  hashThresholdBytes,
 }: CreateOnSendHookOptions) => {
   const onSendHandler: onSendAsyncHookHandler = async (
     request: FastifyRequest,
     reply: FastifyReply,
-    payload: unknown
+    payload: unknown,
   ) => {
     if (reply.getHeader("x-cache") === "miss" && reply.statusCode === 200) {
+      const { key, hashed } = buildCacheKey(request.url, {
+        hashKey,
+        hashThresholdBytes,
+      });
       const expiration = Math.floor(new Date().getTime() / 1000) + ttlSeconds; // TTL in seconds
       const command = new PutItemCommand({
         TableName: tableName,
         Item: {
-          path: { S: request.url },
+          path: { S: key },
           ttl: { N: expiration.toString() },
           data: { S: JSON.stringify(payload, undefined, 0) },
+          // Keep the original URL inspectable when the key has been hashed.
+          ...(hashed ? { url: { S: request.url } } : {}),
         },
       });
 
       try {
         await dynamoClient.send(command);
       } catch (error) {
-        request.log.fatal(error, "Caching new values failed.");
+        request.log.fatal(
+          { error, url: request.url },
+          "Caching new values failed.",
+        );
       }
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { createOnSendHook } from "./hooks/onSend";
  * @property {number} defaultTTLSeconds - Global default TTL (in seconds) for all cache entries.
  * @property {boolean} [disableCache=false] - If true, disables caching plugin-wide.
  * @property {string} [passthroughQueryParam] - If defined, this query parameter will bypass cache when present in a request.
+ * @property {number} [hashThresholdBytes=2048] - Byte size above which a cache key is hashed automatically, as a safety net against DynamoDB's 2048-byte hash key limit.
  */
 export interface DynamodbCachePluginOptions {
   dynamoDbRegion: string;
@@ -21,6 +22,7 @@ export interface DynamodbCachePluginOptions {
   defaultTTLSeconds: number;
   disableCache?: boolean;
   passthroughQueryParam?: string;
+  hashThresholdBytes?: number;
 }
 
 /**
@@ -67,6 +69,8 @@ export const dynamodbCache: FastifyPluginAsync<DynamodbCachePluginOptions> = (
         dynamoClient,
         tableName: opts.tableName,
         passthroughQueryParam: opts.passthroughQueryParam,
+        hashKey: routeOptions.config.cache.hashKey,
+        hashThresholdBytes: opts.hashThresholdBytes,
       });
 
       const onSendHook = createOnSendHook({
@@ -74,6 +78,8 @@ export const dynamodbCache: FastifyPluginAsync<DynamodbCachePluginOptions> = (
         tableName: opts.tableName,
         ttlSeconds:
           routeOptions.config.cache.ttlSeconds || opts.defaultTTLSeconds, // Defaults to "defaultTTLSeconds" which is specified when registering the plugin
+        hashKey: routeOptions.config.cache.hashKey,
+        hashThresholdBytes: opts.hashThresholdBytes,
       });
 
       if (Array.isArray(routeOptions.onRequest)) {
@@ -110,6 +116,12 @@ declare module "fastify" {
        * TTL in seconds for the cached response. Overrides global defaultTTLSeconds if set.
        */
       ttlSeconds?: number;
+      /**
+       * Force hashing of this route's cache key regardless of its size. Keys
+       * are also hashed automatically when they exceed the plugin's
+       * hashThresholdBytes.
+       */
+      hashKey?: boolean;
     };
   }
 }


### PR DESCRIPTION
## What

Long request URLs (path + query params) were exceeding DynamoDB's 2048-byte
hash key limit for clients, throwing `Size of hashkey has exceeded the maximum size limit
of 2048 bytes`.

This hashes the cache key (SHA-256) when needed:
- **Per-route** via `config.cache.hashKey: true`
- **Automatically** when the URL exceeds `hashThresholdBytes` (plugin option, default 2048)

Hashed rows also store the original `url` as a separate attribute so they stay inspectable.

## Notes

⚠️ Behavior change: routes with URLs over the threshold now hash their key, so their
old cache entries are orphaned and repopulate on the next request. Warrants a major bump.