### PR TITLE
build(release): update NPMJS release flow based on OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - "main"
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   install-and-test:
     runs-on: ubuntu-latest
@@ -65,17 +69,16 @@ jobs:
     runs-on: ubuntu-latest
     name: "Releases package to NPM registry"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
           scope: "@blastorg"
+          package-manager-cache: false
       - run: npm ci
       - run: npm run build
       - run: npm version ${{ needs.release.outputs.new-release-version }} --no-git-tag-version --no-commit-hooks --allow-same-version
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_READWRITE_TOKEN }}


### PR DESCRIPTION
NPMjs recommends using OIDC to release rather than long living tokens.

Previous major release failed because the token expired so updating it to use OIDC

ref: https://docs.npmjs.com/trusted-publishers